### PR TITLE
modify description after excute `go build ./cmd/abigen` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ bash tools/download_solc.sh -v 0.4.25
 go build ./cmd/abigen
 ```
 
-执行命令后，检查根目录下是否存在`abigen`，并将生成的`abigen`以及所准备的智能合约`Store.sol`放置在一个新的目录下：
+执行命令后，检查根目录下是否存在`abigen`，并将准备的智能合约`Store.sol`放置在一个新的目录下：
 
 ```
 mkdir ./store


### PR DESCRIPTION
User does not need to move abigen tool to ./store directory, after excutes `go build ./cmd/abigen` command。Only to move Store.sol file to ./store directory.