### PR TITLE
fix: support decimal transaction index

### DIFF
--- a/cmd/commandline/commands.go
+++ b/cmd/commandline/commands.go
@@ -437,7 +437,7 @@ var getTransactionByBlockHashAndIndexCmd = &cobra.Command{
 	Long: `Returns transaction information based on block hash and transaction index inside the block.
 Arguments:
        [blockHash]: block hash string.
-[transactionIndex]: index for the transaction that must be encoded in hex format(prefix with "0x").
+[transactionIndex]: can be input in a decimal or in hex(prefix with "0x").
 
 For example:
 
@@ -451,12 +451,6 @@ For more information please refer:
 		_, err := isValidHex(args[0])
 		if err != nil {
 			fmt.Println(err)
-			return
-		}
-
-		// starts with "0x"
-		if !strings.HasPrefix(args[1], "0x") {
-			fmt.Println("Arguments error: Not a valid hex string, please check your inpunt: ", args[1], info)
 			return
 		}
 
@@ -483,7 +477,7 @@ var getTransactionByBlockNumberAndIndexCmd = &cobra.Command{
 	Long: `Returns transaction information based on block number and transaction index inside the block.
 Arguments:
      [blockNumber]: block number encoded in decimal format or in hex(prefix with "0x").
-[transactionIndex]: index for the transaction that must be encoded in hex format(prefix with "0x").
+[transactionIndex]: can be input in a decimal or in hex(prefix with "0x").
 
 For example:
 
@@ -494,15 +488,15 @@ For more information please refer:
     https://fisco-bcos-documentation.readthedocs.io/zh_CN/latest/docs/api.html#`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		_, err := isValidNumber(args[0])
+		bnum, err := isValidNumber(args[0])
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
 
-		// starts with "0x"
-		if !strings.HasPrefix(args[1], "0x") {
-			fmt.Println("Arguments error: Not a valid hex string, please check your inpunt: ", args[1], info)
+		_, err = isOutOfRange(bnum)
+		if err != nil {
+			fmt.Println(err)
 			return
 		}
 

--- a/cmd/commandline/commands.go
+++ b/cmd/commandline/commands.go
@@ -652,7 +652,7 @@ var getSystemConfigByKeyCmd = &cobra.Command{
 	Short: "[configurationItem]                Get the system configuration through key-value",
 	Long: `Returns the system configuration through key-value.
 Arguments:
-[key to query]: currently only support four key: "tx_count_limit", "tx_gas_limit", "rpbft_epoch_sealer_num", "rpbft_epoch_block_num".
+[key to query]: currently only support four key: "tx_count_limit", "tx_gas_limit", "rpbft_epoch_sealer_num", "rpbft_epoch_block_num", "consensus_timeout".
 
 For example:
 
@@ -663,8 +663,14 @@ For more information please refer:
     https://fisco-bcos-documentation.readthedocs.io/zh_CN/latest/docs/api.html#`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if args[0] != "tx_count_limit" && args[0] != "tx_gas_limit" {
-			fmt.Println("The key not found: ", args[0], ", currently only support [tx_count_limit] and [tx_gas_limit]")
+		configMap := make(map[string]struct{})
+		configMap["tx_count_limit"] = struct{}{}
+		configMap["tx_gas_limit"] = struct{}{}
+		configMap["rpbft_epoch_sealer_num"] = struct{}{}
+		configMap["rpbft_epoch_block_num"] = struct{}{}
+		configMap["consensus_timeout"] = struct{}{}
+		if _, ok := configMap[args[0]]; !ok {
+			fmt.Println("The key not found: ", args[0], ", currently only support [tx_count_limit], [tx_gas_limit], [rpbft_epoch_sealer_num], [rpbft_epoch_block_num] and [consensus_timeout]")
 			return
 		}
 		key := args[0]

--- a/cmd/commandline/system_config.go
+++ b/cmd/commandline/system_config.go
@@ -12,7 +12,7 @@ var setSystemConfigByKey = &cobra.Command{
 	Short: "[system_configuration_item]        Set the system configuration through key-value",
 	Long: `Returns the system configuration through key-value.
 Arguments:
-	  [key]: currently only support four key: "tx_count_limit", "tx_gas_limit", "rpbft_epoch_sealer_num" and "rpbft_epoch_block_num".
+	  [key]: currently only support four key: "tx_count_limit", "tx_gas_limit", "rpbft_epoch_sealer_num", "rpbft_epoch_block_num", "consensus_timeout".
 [key value]: the value of corresponding key.
 
 For example:
@@ -29,8 +29,9 @@ For more information please refer:
 		configMap["tx_gas_limit"] = struct{}{}
 		configMap["rpbft_epoch_sealer_num"] = struct{}{}
 		configMap["rpbft_epoch_block_num"] = struct{}{}
+		configMap["consensus_timeout"] = struct{}{}
 		if _, ok := configMap[args[0]]; !ok {
-			fmt.Println("The key not found: ", args[0], ", currently only support [tx_count_limit], [tx_gas_limit], [rpbft_epoch_sealer_num] and [rpbft_epoch_block_num]")
+			fmt.Println("The key not found: ", args[0], ", currently only support [tx_count_limit], [tx_gas_limit], [rpbft_epoch_sealer_num], [rpbft_epoch_block_num] and [consensus_timeout]")
 			return
 		}
 		key := args[0]


### PR DESCRIPTION
support decimal transaction index for getTransactionByBlockHashAndIndex and getTransactionByBlockNumberAndIndex command