### PR TITLE
fix: already subscribe to topic

### DIFF
--- a/conn/channel.go
+++ b/conn/channel.go
@@ -382,10 +382,10 @@ func DialChannelWithClient(endpoint string, config *tls.Config, groupID int) (*C
 		if err = ch.handshakeChannel(); err != nil {
 			logrus.Errorf("handshake channel protocol failed, use default protocol version")
 		}
-		ch.topicHandlers[blockNotifyPrefix+strconv.Itoa(groupID)] = nil
-		if err = ch.sendSubscribedTopics(); err != nil {
-			return nil, fmt.Errorf("subscriber block nofity failed")
-		}
+		// ch.topicHandlers[blockNotifyPrefix+strconv.Itoa(groupID)] = nil
+		// if err = ch.sendSubscribedTopics(); err != nil {
+		// 	return nil, fmt.Errorf("subscriber block nofity failed")
+		// }
 		return ch, nil
 	})
 }

--- a/conn/channel.go
+++ b/conn/channel.go
@@ -382,10 +382,10 @@ func DialChannelWithClient(endpoint string, config *tls.Config, groupID int) (*C
 		if err = ch.handshakeChannel(); err != nil {
 			logrus.Errorf("handshake channel protocol failed, use default protocol version")
 		}
-		// ch.topicHandlers[blockNotifyPrefix+strconv.Itoa(groupID)] = nil
-		// if err = ch.sendSubscribedTopics(); err != nil {
-		// 	return nil, fmt.Errorf("subscriber block nofity failed")
-		// }
+		ch.topicHandlers[blockNotifyPrefix+strconv.Itoa(groupID)] = nil
+		if err = ch.sendSubscribedTopics(); err != nil {
+			return nil, fmt.Errorf("subscriber block nofity failed")
+		}
 		return ch, nil
 	})
 }
@@ -752,7 +752,7 @@ func (hc *channelSession) subscribeTopic(topic string, handler func([]byte, *[]b
 	if handler == nil {
 		return errors.New("handler is nil")
 	}
-	if _, ok := hc.topicHandlers[topic]; ok {
+	if oldHandler, ok := hc.topicHandlers[topic]; ok && oldHandler != nil {
 		return errors.New("already subscribed to topic " + topic)
 	}
 	hc.topicMu.Lock()


### PR DESCRIPTION
修复在使用SubscribeBlockNumberNotify()时候，订阅失败的问题。
原因分析：
在客户端与节点拨号连接的时候，该代码注释的位置导致_block_notify_[groupId]这个topic注册了，后面使用客户端调用SubscribeBlockNumberNotify函数注册新的处理器并不能注册成功，而且由于这里的处理器注册是个nil，即使先取消订阅，UnSubscribeBlockNumberNotify,也会失败。