### PR TITLE
chore: update bcos-c-sdk to include memory leak fix

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -2,11 +2,8 @@ module github.com/FISCO-BCOS/go-sdk/v3
 
 go 1.21.5
 
-// Use fork to include memory leak fix: https://github.com/FISCO-BCOS/bcos-c-sdk/pull/240
-replace github.com/FISCO-BCOS/bcos-c-sdk => github.com/b1u3h4t/bcos-c-sdk v0.0.0-20260202062031-f331199f0b7a
-
 require (
-	github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20240726021820-a278b4749e34
+	github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20260206014924-9fc3237a88a3
 	github.com/FISCO-BCOS/crypto v0.0.0-20200202032121-bd8ab0b5d4f1
 	github.com/TarsCloud/TarsGo v1.4.5
 	github.com/deckarep/golang-set/v2 v2.6.0

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -2,7 +2,8 @@ module github.com/FISCO-BCOS/go-sdk/v3
 
 go 1.21.5
 
-// replace github.com/FISCO-BCOS/bcos-c-sdk => ../../bcos-c-sdk
+// Use fork to include memory leak fix: https://github.com/FISCO-BCOS/bcos-c-sdk/pull/240
+replace github.com/FISCO-BCOS/bcos-c-sdk => github.com/b1u3h4t/bcos-c-sdk v0.0.0-20260202062031-f331199f0b7a
 
 require (
 	github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20240726021820-a278b4749e34
@@ -17,7 +18,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/urfave/cli/v2 v2.25.7
 	golang.org/x/crypto v0.18.0
-	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	golang.org/x/time v0.3.0
 )
 
@@ -100,6 +100,7 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -40,8 +40,6 @@ github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EF
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20240726021820-a278b4749e34 h1:4YqD9AkbNjGw83vZzVOc4cLGBaiSNs7DppbpPDNurm8=
-github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20240726021820-a278b4749e34/go.mod h1:n2KxbYa73MW3xdLVu2vpPpoblZMms+CwPmvFkubO9xM=
 github.com/FISCO-BCOS/crypto v0.0.0-20200202032121-bd8ab0b5d4f1 h1:ThPht4qK10+cMZC5COIjHPq0INm5HAMVYqrez5zEgFI=
 github.com/FISCO-BCOS/crypto v0.0.0-20200202032121-bd8ab0b5d4f1/go.mod h1:UrLdwsFrjiaCsvdcPLcH6B7s/FUmym3qfM93u2ziR+4=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
@@ -65,6 +63,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
+github.com/b1u3h4t/bcos-c-sdk v0.0.0-20260202062031-f331199f0b7a h1:zg0ZXHx3M/qBHdvzNcgW+gRFJnlr5glzMyizN90IUK4=
+github.com/b1u3h4t/bcos-c-sdk v0.0.0-20260202062031-f331199f0b7a/go.mod h1:n2KxbYa73MW3xdLVu2vpPpoblZMms+CwPmvFkubO9xM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -40,6 +40,10 @@ github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EF
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20240726021820-a278b4749e34 h1:4YqD9AkbNjGw83vZzVOc4cLGBaiSNs7DppbpPDNurm8=
+github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20240726021820-a278b4749e34/go.mod h1:n2KxbYa73MW3xdLVu2vpPpoblZMms+CwPmvFkubO9xM=
+github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20260206014924-9fc3237a88a3 h1:s9mnRBEi551hJMFmO+axqiXJlwVd5VexPAnxej+8HmU=
+github.com/FISCO-BCOS/bcos-c-sdk v0.0.0-20260206014924-9fc3237a88a3/go.mod h1:n2KxbYa73MW3xdLVu2vpPpoblZMms+CwPmvFkubO9xM=
 github.com/FISCO-BCOS/crypto v0.0.0-20200202032121-bd8ab0b5d4f1 h1:ThPht4qK10+cMZC5COIjHPq0INm5HAMVYqrez5zEgFI=
 github.com/FISCO-BCOS/crypto v0.0.0-20200202032121-bd8ab0b5d4f1/go.mod h1:UrLdwsFrjiaCsvdcPLcH6B7s/FUmym3qfM93u2ziR+4=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
@@ -63,8 +67,6 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
-github.com/b1u3h4t/bcos-c-sdk v0.0.0-20260202062031-f331199f0b7a h1:zg0ZXHx3M/qBHdvzNcgW+gRFJnlr5glzMyizN90IUK4=
-github.com/b1u3h4t/bcos-c-sdk v0.0.0-20260202062031-f331199f0b7a/go.mod h1:n2KxbYa73MW3xdLVu2vpPpoblZMms+CwPmvFkubO9xM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
## Summary
- Update bcos-c-sdk dependency to include memory leak fix
- Uses fork version temporarily until upstream PR is merged

## Related PRs
- bcos-c-sdk: https://github.com/FISCO-BCOS/bcos-c-sdk/pull/240

## Changes
- Add replace directive in v3/go.mod to use fork version of bcos-c-sdk
- This includes the fix for memory leak in `NewSDK` function (missing `C.free(cHost)`)

## Note
Once https://github.com/FISCO-BCOS/bcos-c-sdk/pull/240 is merged, this replace directive should be removed and the dependency updated to the new release version.

Made with [Cursor](https://cursor.com)